### PR TITLE
Fix Go static license checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.

--- a/controllers/applicationsnapshotenvironmentbinding_controller.go
+++ b/controllers/applicationsnapshotenvironmentbinding_controller.go
@@ -19,10 +19,11 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+
 	gitopsgenv1alpha1 "github.com/redhat-developer/gitops-generator/api/v1alpha1"
 	gitopsgen "github.com/redhat-developer/gitops-generator/pkg"
 	corev1 "k8s.io/api/core/v1"
-	"path/filepath"
 
 	"github.com/go-logr/logr"
 	kcpclient "github.com/kcp-dev/apimachinery/pkg/client"

--- a/controllers/component_controller_finalizer.go
+++ b/controllers/component_controller_finalizer.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+
 	gitopsgen "github.com/redhat-developer/gitops-generator/pkg"
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"

--- a/gitops/generate.go
+++ b/gitops/generate.go
@@ -17,11 +17,11 @@ package gitops
 
 import (
 	"fmt"
-	gitopsgen "github.com/redhat-developer/gitops-generator/pkg"
 	"path/filepath"
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	"github.com/redhat-appstudio/application-service/gitops/prepare"
+	gitopsgen "github.com/redhat-developer/gitops-generator/pkg"
 	"github.com/spf13/afero"
 )
 

--- a/gitops/generate_build.go
+++ b/gitops/generate_build.go
@@ -19,12 +19,13 @@ package gitops
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/redhat-developer/gitops-generator/pkg/resources"
-	"github.com/redhat-developer/gitops-generator/pkg/yaml"
 	"net/url"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/redhat-developer/gitops-generator/pkg/resources"
+	"github.com/redhat-developer/gitops-generator/pkg/yaml"
 
 	devfilev1alpha2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	devfilecommon "github.com/devfile/library/pkg/devfile/parser/data/v2/common"

--- a/gitops/generate_test.go
+++ b/gitops/generate_test.go
@@ -16,6 +16,9 @@
 package gitops
 
 import (
+	"path/filepath"
+	"testing"
+
 	"github.com/mitchellh/go-homedir"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	"github.com/redhat-appstudio/application-service/gitops/prepare"
@@ -24,8 +27,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"path/filepath"
-	"testing"
 )
 
 func TestGenerateTektonBuild(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/redhat-appstudio/application-service/gitops"
 	"log"
 	"os"
+
+	"github.com/redhat-appstudio/application-service/gitops"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -54,6 +55,7 @@ import (
 	"github.com/redhat-appstudio/application-service/pkg/util/ioutils"
 	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
 	gitopsgen "github.com/redhat-developer/gitops-generator/pkg"
+
 	//+kubebuilder:scaffold:imports
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 )

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,14 +17,15 @@ package util
 
 import (
 	"fmt"
-	gitopsgenv1alpha1 "github.com/redhat-developer/gitops-generator/api/v1alpha1"
 	"io/ioutil"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 	"net/url"
 	"os"
 	"regexp"
 	"strings"
+
+	gitopsgenv1alpha1 "github.com/redhat-developer/gitops-generator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/go-git/go-git/v5"
 	transportHttp "github.com/go-git/go-git/v5/plumbing/transport/http"

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -17,13 +17,14 @@ package util
 
 import (
 	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
 	gitopsgenv1alpha1 "github.com/redhat-developer/gitops-generator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
-	"reflect"
-	"testing"
 
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
The Go static checks in the HAS PR workflow uses `goimports` to validate that the imports in our Go files are properly formatted, but our `make fmt` command doesn't actually use `goimports` to fix the imports.

I just ran `goimports -w $(find . -not -path '*/\.*' -not -name '*zz_generated*.go' -name '*.go')` to fix the imports, followed by `make check_fmt` to validate everything was good.

I'll investigate later how to update our `make fmt` target to call `goimports`